### PR TITLE
fix: update to new github maintainer fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,23 @@
 
 # asdf-aws-nuke ![Build](https://github.com/bersalazar/asdf-aws-nuke/workflows/Build/badge.svg) ![Lint](https://github.com/bersalazar/asdf-aws-nuke/workflows/Lint/badge.svg)
 
-[aws-nuke](https://github.com/rebuy-de/aws-nuke) plugin for the [asdf version manager](https://asdf-vm.com).
+[aws-nuke](https://github.com/ekristen/aws-nuke) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 
 # Contents
 
+- [History](#history)
 - [Dependencies](#dependencies)
 - [Install](#install)
 - [Why?](#why)
 - [Contributing](#contributing)
 - [License](#license)
+
+# History
+
+The `ekristen` fork of aws-nuke is based on the [original](https://github.com/rebuy-de/aws-nuke). `rebuy-de` have offically deprecated their repo and indicate `ekristen` is
+the preferred fork as evidenced in their [README.md](https://github.com/rebuy-de/aws-nuke/blob/main/README.md)
 
 # Dependencies
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/rebuy-de/aws-nuke"
+GH_REPO="https://github.com/ekristen/aws-nuke"
 ARCH="amd64"
 
 fail() {


### PR DESCRIPTION
rebuy-de have deprecated their repo and officially designated ekristen as the new maintainer. This PR updates the fork URL and adds a notice in the repo about the fork history.